### PR TITLE
✨(commit-action): add  semantic-gitmoji commit support

### DIFF
--- a/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
@@ -45,7 +45,7 @@ class GitCommitAction : AnAction() {
         loadGitmojiFromHTTP()
     }
 
-    val codeRegex = Regex(":[a-z0-9_]+:")
+    val regexPattern = ":[a-z0-9_]+:"
 
 
     override fun actionPerformed(e: AnActionEvent) {
@@ -124,12 +124,13 @@ class GitCommitAction : AnAction() {
         groupId: Any
     ) =
         CommandProcessor.getInstance().executeCommand(project, {
-            val useUnicode = PropertiesComponent.getInstance(project).getBoolean(CONFIG_USE_UNICODE, false)
+            val projectInstance = PropertiesComponent.getInstance(project)
+            val useUnicode = projectInstance.getBoolean(CONFIG_USE_UNICODE, false)
             var message = commitMessage.editorField.text
             val selectionStart: Int
+            val textAfterUnicode = projectInstance.getValue(CONFIG_AFTER_UNICODE, " ")
             if (useUnicode) {
                 var replaced = false
-                val textAfterUnicode = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE, " ")
 
                 for (moji in gitmojis) {
                     if (message.contains("${moji.emoji}$textAfterUnicode")) {
@@ -141,21 +142,22 @@ class GitCommitAction : AnAction() {
                 if (!replaced) {
                     message = "${gitmoji.emoji}$textAfterUnicode$message"
                 }
-                selectionStart = gitmoji.emoji.length + (textAfterUnicode?.length ?: 0)
+                selectionStart = gitmoji.emoji.length + textAfterUnicode.length
             } else {
-                message = if (codeRegex.containsMatchIn(message)) {
-                    codeRegex.replace(message, gitmoji.code)
+                val actualRegex = Regex(regexPattern + Regex.escape(textAfterUnicode))
+                message = if (actualRegex.containsMatchIn(message)) {
+                    actualRegex.replace(message, gitmoji.code + textAfterUnicode)
                 } else {
-                    gitmoji.code + " " + message
+                    gitmoji.code + textAfterUnicode + message
                 }
-                selectionStart = gitmoji.code.length + 1
+                selectionStart = gitmoji.code.length + textAfterUnicode.length
             }
             commitMessage.setCommitMessage(message)
             commitMessage.editorField.selectAll()
             commitMessage.editorField.caretModel.removeSecondaryCarets()
             commitMessage.editorField.caretModel.primaryCaret.setSelection(
                 selectionStart,
-                commitMessage.editorField.document.getTextLength(),
+                commitMessage.editorField.document.textLength,
                 false
             )
         }, "", groupId, commitMessage.editorField.document)

--- a/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
@@ -130,21 +130,17 @@ class GitCommitAction : AnAction() {
             if (useUnicode) {
                 var replaced = false
                 for (moji in gitmojis) {
-                    if (message.contains("${moji.emoji} ")) {
-                        message = message.replaceFirst("${moji.emoji} ", "${gitmoji.emoji} ")
-                        replaced = true
-                        break
-                    } else if (message.contains("${moji.emoji}(")) {
-                        // to support semantic-gitmoji commits like: ✨(frontend): new feature...
-                        message = message.replaceFirst("${moji.emoji}(", "${gitmoji.emoji}(")
+                    if (message.contains("${moji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}")) {
+                        message = message.replaceFirst("${moji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}", "${gitmoji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}")
                         replaced = true
                         break
                     }
                 }
                 if (!replaced) {
-                    message = "${gitmoji.emoji} $message"
+                    message = "${gitmoji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}$message"
                 }
-                selectionStart = gitmoji.emoji.length + 1
+                selectionStart = gitmoji.emoji.length + (PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)?.length
+                        ?: 0)
             } else {
                 message = if (codeRegex.containsMatchIn(message)) {
                     codeRegex.replace(message, gitmoji.code)

--- a/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
@@ -134,6 +134,11 @@ class GitCommitAction : AnAction() {
                         message = message.replaceFirst("${moji.emoji} ", "${gitmoji.emoji} ")
                         replaced = true
                         break
+                    } else if (message.contains("${moji.emoji}(")) {
+                        // to support semantic-gitmoji commits like: ✨(frontend): new feature...
+                        message = message.replaceFirst("${moji.emoji}(", "${gitmoji.emoji}(")
+                        replaced = true
+                        break
                     }
                 }
                 if (!replaced) {

--- a/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
@@ -129,7 +129,7 @@ class GitCommitAction : AnAction() {
             val selectionStart: Int
             if (useUnicode) {
                 var replaced = false
-                val textAfterUnicode = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)
+                val textAfterUnicode = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE, " ")
 
                 for (moji in gitmojis) {
                     if (message.contains("${moji.emoji}$textAfterUnicode")) {

--- a/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitCommitAction.kt
@@ -129,18 +129,19 @@ class GitCommitAction : AnAction() {
             val selectionStart: Int
             if (useUnicode) {
                 var replaced = false
+                val textAfterUnicode = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)
+
                 for (moji in gitmojis) {
-                    if (message.contains("${moji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}")) {
-                        message = message.replaceFirst("${moji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}", "${gitmoji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}")
+                    if (message.contains("${moji.emoji}$textAfterUnicode")) {
+                        message = message.replaceFirst("${moji.emoji}$textAfterUnicode", "${gitmoji.emoji}$textAfterUnicode")
                         replaced = true
                         break
                     }
                 }
                 if (!replaced) {
-                    message = "${gitmoji.emoji}${PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)}$message"
+                    message = "${gitmoji.emoji}$textAfterUnicode$message"
                 }
-                selectionStart = gitmoji.emoji.length + (PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE)?.length
-                        ?: 0)
+                selectionStart = gitmoji.emoji.length + (textAfterUnicode?.length ?: 0)
             } else {
                 message = if (codeRegex.containsMatchIn(message)) {
                     codeRegex.replace(message, gitmoji.code)

--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -51,7 +51,7 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
 
         useUnicode.isSelected = useUnicodeConfig
         textAfterUnicode.selectedIndex = when (textAfterUnicodeOptions.indexOf(textAfterUnicodeConfig)) {
-            -1 -> 0
+            -1 -> 1
             else -> textAfterUnicodeOptions.indexOf(textAfterUnicodeConfig)
         }
     }

--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -12,7 +12,7 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
     private val mainPanel: JPanel
     private val useUnicode = JCheckBox("Use unicode emoji instead of text version (:code:)")
     private var useUnicodeConfig: Boolean = false
-    private val textAfterUnicodeOptions = arrayOf("<nothing>", "<space>", ":", "(", "_", "[")
+    private val textAfterUnicodeOptions = arrayOf("<nothing>", "<space>", ":", "(", "_", "[", "-")
     private val textAfterUnicode = ComboBox(textAfterUnicodeOptions)
     private var textAfterUnicodeConfig: String = " "
 

--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -4,13 +4,9 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
-import java.awt.BorderLayout
-import java.awt.CardLayout
 import java.awt.FlowLayout
 import java.awt.GridLayout
-import java.util.*
 import javax.swing.*
-import kotlin.properties.Delegates
 
 class GitMojiConfig constructor(private val project: Project) : SearchableConfigurable {
     private val mainPanel: JPanel

--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -4,31 +4,39 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import java.awt.BorderLayout
-import javax.swing.JCheckBox
-import javax.swing.JComponent
-import javax.swing.JPanel
+import javax.swing.*
 
-class GitMojiConfig constructor(val project: Project) : SearchableConfigurable {
-    private val mainPanel: JPanel
+class GitMojiConfig constructor(private val project: Project) : SearchableConfigurable {
+    private val mainPanel: JPanel = JPanel(BorderLayout())
     private val useUnicode = JCheckBox("Use unicode emoji instead of text version (:code:)")
     private var useUnicodeConfig : Boolean = false
-    override fun isModified(): Boolean = isModified(useUnicode, useUnicodeConfig)
+    private val textAfterUnicode = JTextField("Character / text displayed after unicode character. Default: ' '")
+    private var textAfterUnicodeConfig : String = " "
+
+    private val group : GroupLayout = GroupLayout(mainPanel)
+
+    override fun isModified(): Boolean = isModified(useUnicode, useUnicodeConfig) || isModified(textAfterUnicode, textAfterUnicodeConfig)
     override fun getDisplayName(): String = "Gitmoji"
     override fun getId(): String = "com.github.patou.gitmoji.config"
     init
     {
-        mainPanel = JPanel(BorderLayout())
         mainPanel.add(BorderLayout.NORTH, useUnicode)
+        mainPanel.add(BorderLayout.AFTER_LAST_LINE, textAfterUnicode)
     }
 
     override fun apply() {
         useUnicodeConfig = useUnicode.isSelected
+        textAfterUnicodeConfig = textAfterUnicode.text
+
         PropertiesComponent.getInstance(project).setValue(CONFIG_USE_UNICODE, useUnicodeConfig)
+        PropertiesComponent.getInstance(project).setValue(CONFIG_AFTER_UNICODE, textAfterUnicodeConfig)
     }
 
     override fun reset() {
         useUnicodeConfig = PropertiesComponent.getInstance(project).getBoolean(CONFIG_USE_UNICODE, false)
+        textAfterUnicodeConfig = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE, " ")
         useUnicode.isSelected = useUnicodeConfig
+        textAfterUnicode.text = textAfterUnicodeConfig
     }
 
     override fun createComponent(): JComponent? = mainPanel

--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -12,7 +12,7 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
     private val mainPanel: JPanel
     private val useUnicode = JCheckBox("Use unicode emoji instead of text version (:code:)")
     private var useUnicodeConfig: Boolean = false
-    private val textAfterUnicodeOptions = arrayOf("<nothing>", "<space>", ":", "(", "_")
+    private val textAfterUnicodeOptions = arrayOf("<nothing>", "<space>", ":", "(", "_", "[")
     private val textAfterUnicode = ComboBox(textAfterUnicodeOptions)
     private var textAfterUnicodeConfig: String = " "
 
@@ -38,13 +38,17 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
             else -> textAfterUnicodeOptions[textAfterUnicode.selectedIndex]
         }
 
-        PropertiesComponent.getInstance(project).setValue(CONFIG_USE_UNICODE, useUnicodeConfig)
-        PropertiesComponent.getInstance(project).setValue(CONFIG_AFTER_UNICODE, textAfterUnicodeConfig)
+        val projectInstance = PropertiesComponent.getInstance(project)
+        projectInstance.setValue(CONFIG_USE_UNICODE, useUnicodeConfig)
+        projectInstance.setValue(CONFIG_AFTER_UNICODE, textAfterUnicodeConfig)
     }
 
     override fun reset() {
-        useUnicodeConfig = PropertiesComponent.getInstance(project).getBoolean(CONFIG_USE_UNICODE, false)
-        textAfterUnicodeConfig = PropertiesComponent.getInstance(project).getValue(CONFIG_AFTER_UNICODE, " ")
+        val propertiesComponent = PropertiesComponent.getInstance(project)
+
+        useUnicodeConfig = propertiesComponent.getBoolean(CONFIG_USE_UNICODE, false)
+        textAfterUnicodeConfig = propertiesComponent.getValue(CONFIG_AFTER_UNICODE, " ")
+
         useUnicode.isSelected = useUnicodeConfig
         textAfterUnicode.selectedIndex = when (textAfterUnicodeOptions.indexOf(textAfterUnicodeConfig)) {
             -1 -> 0
@@ -52,7 +56,5 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
         }
     }
 
-    override fun createComponent(): JComponent? = mainPanel
-
-
+    override fun createComponent(): JComponent = mainPanel
 }

--- a/src/main/kotlin/com/github/patou/gitmoji/GitmojiData.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitmojiData.kt
@@ -2,4 +2,5 @@ package com.github.patou.gitmoji
 
 const val CONFIG_USE_UNICODE: String = "com.github.patou.gitmoji.use-unicode"
 const val CONFIG_AFTER_UNICODE: String = "com.github.patou.gitmoji.text-after-unicode"
+
 data class GitmojiData(val code: String, val emoji: String, val description: String)

--- a/src/main/kotlin/com/github/patou/gitmoji/GitmojiData.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitmojiData.kt
@@ -1,4 +1,5 @@
 package com.github.patou.gitmoji
 
 const val CONFIG_USE_UNICODE: String = "com.github.patou.gitmoji.use-unicode"
+const val CONFIG_AFTER_UNICODE: String = "com.github.patou.gitmoji.text-after-unicode"
 data class GitmojiData(val code: String, val emoji: String, val description: String)


### PR DESCRIPTION
At my company we mainly use the semantic commit style of the form: <type>(<scope>): <subject> - `✨(scope): subject`

To use this with gitmoji it would be perfect, if the plugin won't remove the first parentheses with a space, if I choose one emoji and if the plugin knows that a gitmoji don't need a spacer behind - with the actual implementations there will be a duplicate emoji, if a parentheses follows directly.

Another addition, I may add it if you like, is to allow additionally an ':' for styles like `✨: ...`