### PR TITLE
:alien: Add isModified for ComboBox

### DIFF
--- a/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/GitMojiConfig.kt
@@ -4,6 +4,7 @@ import com.intellij.ide.util.PropertiesComponent
 import com.intellij.openapi.options.SearchableConfigurable
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.ComboBox
+import com.intellij.openapi.util.Comparing
 import java.awt.FlowLayout
 import java.awt.GridLayout
 import javax.swing.JCheckBox
@@ -30,6 +31,10 @@ class GitMojiConfig constructor(private val project: Project) : SearchableConfig
                 isModified(useUnicode, useUnicodeConfig) ||
                 isModified(textAfterUnicode, textAfterUnicodeConfig) ||
                 isModified(insertInCursorPosition, insertInCursorPositionConfig)
+
+    private fun isModified(comboBox: ComboBox<String>, value: String): Boolean {
+        return !Comparing.equal(comboBox.selectedItem, value)
+    }
 
     override fun getDisplayName(): String = "Gitmoji"
     override fun getId(): String = "com.github.patou.gitmoji.config"


### PR DESCRIPTION
This is a problem from the 2021.3 and later versions.

The `Configurable` interface no longer supports the `equal check method for ComboBox` from version 2021.3

So I added a method to `GitMojiConfig.kt`.

![image](https://user-images.githubusercontent.com/32251594/146638189-86aec1a8-8be3-4641-9c58-e133bc3521dd.png)
![image](https://user-images.githubusercontent.com/32251594/146638209-4df65bb2-4a1a-4ff7-a596-3091072b7001.png)
