### PR TITLE
📝 Update conventional gitmoji web url

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This plug-in will help you to choose and add the gitmoji, via a button in the Co
 * Load the list of gitmoji on startup from the repos of gitmoji (fallback to a local list if error).
 * Allow to display the gitmoji in a new column in the commit history
 * Translate the gitmoji description in your chinese and french language.
-* Custom gitmoji list from url or predefined default [Gitmojis](https://gitmoji.dev/) or [Conventional Gitmojis](https://conventional-gitmoji.web.app/)
+* Custom gitmoji list from url or predefined default [Gitmojis](https://gitmoji.dev/) or [Conventional Gitmojis](https://ackeecz.github.io/conventional-gitmoji/)
 
 See the [gitmoji website](https://gitmoji.dev/) for have the list of Emoji and their signification.
 <!-- Plugin description end -->

--- a/custom_gitmojis.md
+++ b/custom_gitmojis.md
@@ -64,7 +64,7 @@ The plugin will try to download remote YAML translations. If the network fetch o
 - The plugin ships a bundled default file at [gitmojis.json](./src/main/resources/gitmojis.json). If an HTTP fetch of the configured JSON URL fails, the plugin falls back to this embedded file.
 - Default localization example file can be found at [gitmojis.yaml](./src/main/resources/gitmojis.yaml).
 - The default remote URL used by the plugin for Gitmoji source is https://gitmoji.dev/api/gitmojis
-- There is also a built-in [Conventional Gitmoji](https://conventional-gitmoji.web.app/) option, which is reduced set of Gitmojis matching the [conventional commit](https://www.conventionalcommits.org) specification.
+- There is also a built-in [Conventional Gitmoji](https://ackeecz.github.io/conventional-gitmoji/) option, which is reduced set of Gitmojis matching the [conventional commit](https://www.conventionalcommits.org) specification.
  
 
 ## Practical example — host custom JSON and YAML on GitHub

--- a/src/main/kotlin/com/github/patou/gitmoji/source/GitmojiSourceType.kt
+++ b/src/main/kotlin/com/github/patou/gitmoji/source/GitmojiSourceType.kt
@@ -47,7 +47,7 @@ sealed interface GitmojiSourceType {
         override val settingsName: String = "Gitmoji Conventional"
         override val jsonUrl: String = "https://raw.githubusercontent.com/glazrtom/conventional-gitmoji-config/refs/heads/master/gitmojis.json"
         override val localizationUrl: String = "https://raw.githubusercontent.com/glazrtom/conventional-gitmoji-config/refs/heads/master/localizations/gitmojis-{locale}.yaml"
-        override val tooltipUrl: String = "https://conventional-gitmoji.web.app/"
+        override val tooltipUrl: String = "https://ackeecz.github.io/conventional-gitmoji/"
         override val tooltipText: String = GitmojiBundle.message("config.source.type.conventionalGitmoji.tooltip")
     }
 


### PR DESCRIPTION
As asked in https://github.com/patou/gitmoji-plus-commit-button/issues/170 here is the updated version with github pages. Thanks!